### PR TITLE
Closes #LOC-23 add iOS UI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,15 @@
 # Ignoring the pod directory 
 PodExample/Pods/
 PodExample/Podfile.lock
+
+# Ignoring Mac OS stuff
 .DS_Store
 .AppleDouble
 .LSOverride
+
+# Ignoring Carthage stuff
 xcuserdata/
 Carthage/
+
+# Ignoring build stuff
+DerivedData/

--- a/FantasmoSDK.xcodeproj/project.pbxproj
+++ b/FantasmoSDK.xcodeproj/project.pbxproj
@@ -173,6 +173,24 @@
 		A3CB77372636BDB8009625BB /* FMOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3CB77362636BDB8009625BB /* FMOrientation.swift */; };
 		A3CB773F263710D2009625BB /* simd_float4x4+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3CB773E263710D2009625BB /* simd_float4x4+Extension.swift */; };
 		A3CB774226372A9B009625BB /* simd_quatf+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3CB774126372A9B009625BB /* simd_quatf+Extension.swift */; };
+		FF2C0C59282A8DAB001A94FD /* DebugQuestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2C0C58282A8DAB001A94FD /* DebugQuestions.swift */; };
+		FF44C8DE28215055002E5FA1 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF44C8DD28215055002E5FA1 /* Extensions.swift */; };
+		FF73CD52281FD699003408E0 /* DebugElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF73CD51281FD699003408E0 /* DebugElements.swift */; };
+		FF73CD54282006E0003408E0 /* LocalizeQuestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF73CD53282006E0003408E0 /* LocalizeQuestions.swift */; };
+		FFB1C144281A7C60008B8DE5 /* LocalizeElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1C143281A7C60008B8DE5 /* LocalizeElements.swift */; };
+		FFB1C146281A7E93008B8DE5 /* UIReleaseProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1C145281A7E93008B8DE5 /* UIReleaseProtocolTests.swift */; };
+		FFB1C148281A81D4008B8DE5 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1C147281A81D4008B8DE5 /* Config.swift */; };
+		FFB1C14B281AAEEB008B8DE5 /* LocalizeActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1C14A281AAEEB008B8DE5 /* LocalizeActions.swift */; };
+		FFB1C14D281AB136008B8DE5 /* LocalizeTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1C14C281AB136008B8DE5 /* LocalizeTasks.swift */; };
+		FFB56BCF28192C2F00CB7514 /* PermissionElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB56BCE28192C2F00CB7514 /* PermissionElements.swift */; };
+		FFB56BD228192D9000CB7514 /* PermissionActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB56BD128192D9000CB7514 /* PermissionActions.swift */; };
+		FFB56BD52819311A00CB7514 /* PermissionTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB56BD42819311A00CB7514 /* PermissionTasks.swift */; };
+		FFB56BD8281934C300CB7514 /* PermissionQuestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB56BD7281934C300CB7514 /* PermissionQuestions.swift */; };
+		FFB56BDB2819354400CB7514 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB56BDA2819354400CB7514 /* Protocols.swift */; };
+		FFB56BDD28193C6600CB7514 /* Actor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB56BDC28193C6600CB7514 /* Actor.swift */; };
+		FFF577F7282BE22D0054CCD4 /* QRCodeElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF577F6282BE22D0054CCD4 /* QRCodeElements.swift */; };
+		FFF577F9282BE3990054CCD4 /* QRCodeTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF577F8282BE3990054CCD4 /* QRCodeTasks.swift */; };
+		FFF577FB282BE3C00054CCD4 /* QRCodeActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF577FA282BE3C00054CCD4 /* QRCodeActions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -210,6 +228,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 9468388A25921BAF005B1145;
 			remoteInfo = FantasmoSDK;
+		};
+		FFB56BC428191AE800CB7514 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9468388225921BAF005B1145 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 018EF38C2795A16A005A1381;
+			remoteInfo = FantasmoSDKTestHarnessDev;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -402,7 +427,26 @@
 		A3CB773E263710D2009625BB /* simd_float4x4+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "simd_float4x4+Extension.swift"; sourceTree = "<group>"; };
 		A3CB774126372A9B009625BB /* simd_quatf+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "simd_quatf+Extension.swift"; sourceTree = "<group>"; };
 		A3EEC0852664EFC6008BCCF2 /* FMFrameFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FMFrameFilter.swift; sourceTree = "<group>"; };
+		FF2C0C58282A8DAB001A94FD /* DebugQuestions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugQuestions.swift; sourceTree = "<group>"; };
+		FF44C8DD28215055002E5FA1 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		FF73CD51281FD699003408E0 /* DebugElements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugElements.swift; sourceTree = "<group>"; };
+		FF73CD53282006E0003408E0 /* LocalizeQuestions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizeQuestions.swift; sourceTree = "<group>"; };
 		FFA8586C2701D5D20069EB5D /* SDKGeometricTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDKGeometricTests.swift; sourceTree = "<group>"; };
+		FFB1C143281A7C60008B8DE5 /* LocalizeElements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizeElements.swift; sourceTree = "<group>"; };
+		FFB1C145281A7E93008B8DE5 /* UIReleaseProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIReleaseProtocolTests.swift; sourceTree = "<group>"; };
+		FFB1C147281A81D4008B8DE5 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		FFB1C14A281AAEEB008B8DE5 /* LocalizeActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizeActions.swift; sourceTree = "<group>"; };
+		FFB1C14C281AB136008B8DE5 /* LocalizeTasks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizeTasks.swift; sourceTree = "<group>"; };
+		FFB56BBE28191AE800CB7514 /* FantasmoSDKUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FantasmoSDKUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FFB56BCE28192C2F00CB7514 /* PermissionElements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionElements.swift; sourceTree = "<group>"; };
+		FFB56BD128192D9000CB7514 /* PermissionActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionActions.swift; sourceTree = "<group>"; };
+		FFB56BD42819311A00CB7514 /* PermissionTasks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionTasks.swift; sourceTree = "<group>"; };
+		FFB56BD7281934C300CB7514 /* PermissionQuestions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionQuestions.swift; sourceTree = "<group>"; };
+		FFB56BDA2819354400CB7514 /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
+		FFB56BDC28193C6600CB7514 /* Actor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Actor.swift; sourceTree = "<group>"; };
+		FFF577F6282BE22D0054CCD4 /* QRCodeElements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeElements.swift; sourceTree = "<group>"; };
+		FFF577F8282BE3990054CCD4 /* QRCodeTasks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeTasks.swift; sourceTree = "<group>"; };
+		FFF577FA282BE3C00054CCD4 /* QRCodeActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeActions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -442,6 +486,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				A0D5E88C26BA97DA00CE5B1C /* FantasmoSDK.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FFB56BBB28191AE700CB7514 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -633,6 +684,7 @@
 				01A3A4F3270F14B000B7679F /* FantasmoSDKParkingExample */,
 				01138A1727551D5F00AB31DF /* FantasmoSDKTestHarness */,
 				A0D5E88826BA97DA00CE5B1C /* FantasmoSDKTests */,
+				FFB56BBF28191AE800CB7514 /* FantasmoSDKUITests */,
 				9468388C25921BAF005B1145 /* Products */,
 				946838E025921DFE005B1145 /* Frameworks */,
 				A3445A0226A8967300C96205 /* Recovered References */,
@@ -647,6 +699,7 @@
 				01A3A4F2270F14B000B7679F /* FantasmoSDKParkingExample.app */,
 				01138A1627551D5F00AB31DF /* FantasmoSDKTestHarness.app */,
 				018EF3A72795A16A005A1381 /* FantasmoSDKTestHarnessDev.app */,
+				FFB56BBE28191AE800CB7514 /* FantasmoSDKUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -871,6 +924,71 @@
 			path = FMPose;
 			sourceTree = "<group>";
 		};
+		FFB56BBF28191AE800CB7514 /* FantasmoSDKUITests */ = {
+			isa = PBXGroup;
+			children = (
+				FFB56BD028192D7300CB7514 /* Actions */,
+				FFB56BCD28192BF400CB7514 /* Elements */,
+				FFB56BD3281930C400CB7514 /* Tasks */,
+				FFB56BD6281934A500CB7514 /* Questions */,
+				FFB56BDE28193C7500CB7514 /* Tests */,
+				FFB56BDC28193C6600CB7514 /* Actor.swift */,
+				FFB56BDA2819354400CB7514 /* Protocols.swift */,
+				FFB1C147281A81D4008B8DE5 /* Config.swift */,
+				FF44C8DD28215055002E5FA1 /* Extensions.swift */,
+			);
+			path = FantasmoSDKUITests;
+			sourceTree = "<group>";
+		};
+		FFB56BCD28192BF400CB7514 /* Elements */ = {
+			isa = PBXGroup;
+			children = (
+				FFB56BCE28192C2F00CB7514 /* PermissionElements.swift */,
+				FFB1C143281A7C60008B8DE5 /* LocalizeElements.swift */,
+				FF73CD51281FD699003408E0 /* DebugElements.swift */,
+				FFF577F6282BE22D0054CCD4 /* QRCodeElements.swift */,
+			);
+			path = Elements;
+			sourceTree = "<group>";
+		};
+		FFB56BD028192D7300CB7514 /* Actions */ = {
+			isa = PBXGroup;
+			children = (
+				FFB56BD128192D9000CB7514 /* PermissionActions.swift */,
+				FFB1C14A281AAEEB008B8DE5 /* LocalizeActions.swift */,
+				FFF577FA282BE3C00054CCD4 /* QRCodeActions.swift */,
+			);
+			path = Actions;
+			sourceTree = "<group>";
+		};
+		FFB56BD3281930C400CB7514 /* Tasks */ = {
+			isa = PBXGroup;
+			children = (
+				FFB56BD42819311A00CB7514 /* PermissionTasks.swift */,
+				FFB1C14C281AB136008B8DE5 /* LocalizeTasks.swift */,
+				FFF577F8282BE3990054CCD4 /* QRCodeTasks.swift */,
+			);
+			path = Tasks;
+			sourceTree = "<group>";
+		};
+		FFB56BD6281934A500CB7514 /* Questions */ = {
+			isa = PBXGroup;
+			children = (
+				FFB56BD7281934C300CB7514 /* PermissionQuestions.swift */,
+				FF73CD53282006E0003408E0 /* LocalizeQuestions.swift */,
+				FF2C0C58282A8DAB001A94FD /* DebugQuestions.swift */,
+			);
+			path = Questions;
+			sourceTree = "<group>";
+		};
+		FFB56BDE28193C7500CB7514 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				FFB1C145281A7E93008B8DE5 /* UIReleaseProtocolTests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -979,13 +1097,33 @@
 			productReference = A0D5E88726BA97DA00CE5B1C /* FantasmoSDKTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		FFB56BBD28191AE700CB7514 /* FantasmoSDKUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FFB56BC828191AE800CB7514 /* Build configuration list for PBXNativeTarget "FantasmoSDKUITests" */;
+			buildPhases = (
+				FFB56BBA28191AE700CB7514 /* Sources */,
+				FFB56BBB28191AE700CB7514 /* Frameworks */,
+				FFB56BBC28191AE700CB7514 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FFB56BC528191AE800CB7514 /* PBXTargetDependency */,
+			);
+			name = FantasmoSDKUITests;
+			packageProductDependencies = (
+			);
+			productName = FantasmoSDKUITests;
+			productReference = FFB56BBE28191AE800CB7514 /* FantasmoSDKUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		9468388225921BAF005B1145 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1310;
+				LastSwiftUpdateCheck = 1330;
 				LastUpgradeCheck = 1310;
 				TargetAttributes = {
 					01138A1527551D5F00AB31DF = {
@@ -1001,6 +1139,10 @@
 						CreatedOnToolsVersion = 12.5.1;
 						TestTargetID = 01138A1527551D5F00AB31DF;
 					};
+					FFB56BBD28191AE700CB7514 = {
+						CreatedOnToolsVersion = 13.3.1;
+						TestTargetID = 018EF38C2795A16A005A1381;
+					};
 				};
 			};
 			buildConfigurationList = 9468388525921BAF005B1145 /* Build configuration list for PBXProject "FantasmoSDK" */;
@@ -1012,6 +1154,8 @@
 				Base,
 			);
 			mainGroup = 9468388125921BAF005B1145;
+			packageReferences = (
+			);
 			productRefGroup = 9468388C25921BAF005B1145 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1021,6 +1165,7 @@
 				01A3A4F1270F14B000B7679F /* FantasmoSDKParkingExample */,
 				01138A1527551D5F00AB31DF /* FantasmoSDKTestHarness */,
 				018EF38C2795A16A005A1381 /* FantasmoSDKTestHarnessDev */,
+				FFB56BBD28191AE700CB7514 /* FantasmoSDKUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -1088,6 +1233,13 @@
 				0119641028085DFC007DDD20 /* dummy-image-quality-model-0.0.1.mlmodelc in Resources */,
 				012C7BF727B19B29003DC67F /* parking-nighttime.mp4 in Resources */,
 				40EA810526E7C6A8002E96A6 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FFB56BBC28191AE700CB7514 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1257,6 +1409,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FFB56BBA28191AE700CB7514 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FF73CD54282006E0003408E0 /* LocalizeQuestions.swift in Sources */,
+				FF2C0C59282A8DAB001A94FD /* DebugQuestions.swift in Sources */,
+				FFB56BDB2819354400CB7514 /* Protocols.swift in Sources */,
+				FFF577F9282BE3990054CCD4 /* QRCodeTasks.swift in Sources */,
+				FF73CD52281FD699003408E0 /* DebugElements.swift in Sources */,
+				FFB56BD8281934C300CB7514 /* PermissionQuestions.swift in Sources */,
+				FFB56BD228192D9000CB7514 /* PermissionActions.swift in Sources */,
+				FFB56BDD28193C6600CB7514 /* Actor.swift in Sources */,
+				FFB1C14D281AB136008B8DE5 /* LocalizeTasks.swift in Sources */,
+				FFB1C148281A81D4008B8DE5 /* Config.swift in Sources */,
+				FFB1C146281A7E93008B8DE5 /* UIReleaseProtocolTests.swift in Sources */,
+				FFF577F7282BE22D0054CCD4 /* QRCodeElements.swift in Sources */,
+				FFB1C14B281AAEEB008B8DE5 /* LocalizeActions.swift in Sources */,
+				FFB1C144281A7C60008B8DE5 /* LocalizeElements.swift in Sources */,
+				FFB56BCF28192C2F00CB7514 /* PermissionElements.swift in Sources */,
+				FFF577FB282BE3C00054CCD4 /* QRCodeActions.swift in Sources */,
+				FF44C8DE28215055002E5FA1 /* Extensions.swift in Sources */,
+				FFB56BD52819311A00CB7514 /* PermissionTasks.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -1284,6 +1461,11 @@
 			isa = PBXTargetDependency;
 			target = 9468388A25921BAF005B1145 /* FantasmoSDK */;
 			targetProxy = A0D5E88D26BA97DA00CE5B1C /* PBXContainerItemProxy */;
+		};
+		FFB56BC528191AE800CB7514 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 018EF38C2795A16A005A1381 /* FantasmoSDKTestHarnessDev */;
+			targetProxy = FFB56BC428191AE800CB7514 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1741,6 +1923,56 @@
 			};
 			name = Release;
 		};
+		FFB56BC628191AE800CB7514 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8V8339VAMG;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"$(LD_RUNPATH_SEARCH_PATHS_SHALLOW_BUNDLE_$(SHALLOW_BUNDLE))",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.fantasmo.FantasmoSDKTestHarnessDev.FantasmoSDKUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = FantasmoSDKTestHarnessDev;
+			};
+			name = Debug;
+		};
+		FFB56BC728191AE800CB7514 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8V8339VAMG;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"$(LD_RUNPATH_SEARCH_PATHS_SHALLOW_BUNDLE_$(SHALLOW_BUNDLE))",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.fantasmo.FantasmoSDKTestHarnessDev.FantasmoSDKUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = FantasmoSDKTestHarnessDev;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1794,6 +2026,15 @@
 			buildConfigurations = (
 				A0D5E89026BA97DA00CE5B1C /* Debug */,
 				A0D5E89126BA97DA00CE5B1C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FFB56BC828191AE800CB7514 /* Build configuration list for PBXNativeTarget "FantasmoSDKUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FFB56BC628191AE800CB7514 /* Debug */,
+				FFB56BC728191AE800CB7514 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/FantasmoSDK.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/FantasmoSDK.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/FantasmoSDK.xcodeproj/xcshareddata/xcschemes/FantasmoSDKTestHarnessDev.xcscheme
+++ b/FantasmoSDK.xcodeproj/xcshareddata/xcschemes/FantasmoSDKTestHarnessDev.xcscheme
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "018EF38C2795A16A005A1381"
+               BuildableName = "FantasmoSDKTestHarnessDev.app"
+               BlueprintName = "FantasmoSDKTestHarnessDev"
+               ReferencedContainer = "container:FantasmoSDK.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FFB56BBD28191AE700CB7514"
+               BuildableName = "FantasmoSDKUITests.xctest"
+               BlueprintName = "FantasmoSDKUITests"
+               ReferencedContainer = "container:FantasmoSDK.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "018EF38C2795A16A005A1381"
+            BuildableName = "FantasmoSDKTestHarnessDev.app"
+            BlueprintName = "FantasmoSDKTestHarnessDev"
+            ReferencedContainer = "container:FantasmoSDK.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "SDK_VERSION"
+            value = "2.3.4"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "018EF38C2795A16A005A1381"
+            BuildableName = "FantasmoSDKTestHarnessDev.app"
+            BlueprintName = "FantasmoSDKTestHarnessDev"
+            ReferencedContainer = "container:FantasmoSDK.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FantasmoSDK/Assets/FMSessionStatisticsView.xib
+++ b/FantasmoSDK/Assets/FMSessionStatisticsView.xib
@@ -28,6 +28,7 @@
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fantasmo SDK" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4MQ-Tu-HZ0" userLabel="sdkVersionLabel">
                                     <rect key="frame" x="0.0" y="0.0" width="197" height="19.5"/>
                                     <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <accessibility key="accessibilityConfiguration" identifier="txt_sdkVersion"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                     <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <nil key="highlightedColor"/>
@@ -35,6 +36,7 @@
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status: stopped" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hd6-Sn-Br5" userLabel="Manager Status Label">
                                     <rect key="frame" x="197" y="0.0" width="197" height="19.5"/>
                                     <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <accessibility key="accessibilityConfiguration" identifier="txt_localizationStatus"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                     <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <nil key="highlightedColor"/>
@@ -50,6 +52,7 @@
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Current window: 0.0s" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kvQ-6t-uup" userLabel="Current Window Label">
                                             <rect key="frame" x="0.0" y="0.0" width="197" height="19.5"/>
                                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <accessibility key="accessibilityConfiguration" identifier="txt_currentWindow"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <nil key="highlightedColor"/>
@@ -57,6 +60,7 @@
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Best score: n/a" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uOF-EP-XNS" userLabel="Best Score Label">
                                             <rect key="frame" x="197" y="0.0" width="197" height="19.5"/>
                                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <accessibility key="accessibilityConfiguration" identifier="txt_bestScore"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <nil key="highlightedColor"/>
@@ -69,6 +73,7 @@
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Frames evaluated: 0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zit-CO-glf" userLabel="Frames Evaluated Label">
                                             <rect key="frame" x="0.0" y="0.0" width="197" height="19.5"/>
                                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <accessibility key="accessibilityConfiguration" identifier="txt_framesEvaluated"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <nil key="highlightedColor"/>
@@ -76,6 +81,7 @@
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Live score: n/a" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ad0-Uk-IvR" userLabel="Live Frame Score Label">
                                             <rect key="frame" x="197" y="0.0" width="197" height="19.5"/>
                                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <accessibility key="accessibilityConfiguration" identifier="txt_liveScore"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <nil key="highlightedColor"/>
@@ -88,6 +94,7 @@
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Frames rejected: 0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rSj-ul-oUr" userLabel="Frames Rejected Label">
                                             <rect key="frame" x="0.0" y="0.0" width="197" height="19.5"/>
                                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <accessibility key="accessibilityConfiguration" identifier="txt_framesRejected"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <nil key="highlightedColor"/>
@@ -106,6 +113,7 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Image Quality Model: " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="msC-8Q-jVi" userLabel="Image Quality Model Label">
                             <rect key="frame" x="0.0" y="93" width="394" height="19.5"/>
                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <accessibility key="accessibilityConfiguration" identifier="txt_modelVersion"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -113,6 +121,7 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Last result:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XKk-ZN-TKq" userLabel="Last Result Label">
                             <rect key="frame" x="0.0" y="117.5" width="394" height="19.5"/>
                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <accessibility key="accessibilityConfiguration" identifier="txt_lastResult"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -120,6 +129,7 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Errors: 0" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PBI-tq-xkJ" userLabel="Errors Label">
                             <rect key="frame" x="0.0" y="142" width="394" height="19.5"/>
                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <accessibility key="accessibilityConfiguration" identifier="txt_errorCount"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -127,6 +137,7 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Device location:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kgX-fc-kHM" userLabel="Device Location Label">
                             <rect key="frame" x="0.0" y="166.5" width="394" height="19.5"/>
                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <accessibility key="accessibilityConfiguration" identifier="txt_deviceLocation"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -134,6 +145,7 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Translation: 0.00, 0.00, 0.00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WUd-b1-MMC" userLabel="Translation Label">
                             <rect key="frame" x="0.0" y="191" width="394" height="19.5"/>
                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <accessibility key="accessibilityConfiguration" identifier="txt_translation"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -141,6 +153,7 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total translation: 0m" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbd-yi-UFp" userLabel="Total Translation Label">
                             <rect key="frame" x="0.0" y="215.5" width="394" height="19.5"/>
                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <accessibility key="accessibilityConfiguration" identifier="txt_totalTranslation"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -148,6 +161,7 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Remote Config:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xFh-gh-OAB" userLabel="Remote Config Label">
                             <rect key="frame" x="0.0" y="240" width="394" height="19.5"/>
                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <accessibility key="accessibilityConfiguration" identifier="txt_remoteConfigID"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -155,6 +169,7 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Euler Angles: 0.00°, 0.00°, 0.00°" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ifi-EE-yAS" userLabel="Euler Angles Label">
                             <rect key="frame" x="0.0" y="264.5" width="394" height="19.5"/>
                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <accessibility key="accessibilityConfiguration" identifier="txt_eulerAngles"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -162,6 +177,7 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jvU-2T-GZj" userLabel="Euler Angle Spreads Label">
                             <rect key="frame" x="0.0" y="289" width="394" height="76.5"/>
                             <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <accessibility key="accessibilityConfiguration" identifier="txt_eulerAngleSpreads"/>
                             <string key="text">Euler Angle Spreads:
 	(0.00°, 0.00°) 0.00°
 	(0.00°, 0.00°) 0.00°
@@ -176,6 +192,7 @@
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Total frame rejections: 0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SuS-7W-uMO" userLabel="Rejection Reasons Label">
                                     <rect key="frame" x="0.0" y="0.0" width="394" height="19.5"/>
                                     <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <accessibility key="accessibilityConfiguration" identifier="txt_totalFrameRejections"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                     <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <nil key="highlightedColor"/>

--- a/FantasmoSDK/Classes/Views/FMQRScanningViewController.swift
+++ b/FantasmoSDK/Classes/Views/FMQRScanningViewController.swift
@@ -88,11 +88,13 @@ public class FMQRScanningViewController: UIViewController {
         view.addSubview(toolbar)
         
         manualEntryButton = buttonWithTitle("Enter Code", imageName: "btn-keyboard")
+        manualEntryButton.isAccessibilityElement = true
         manualEntryButton.addTarget(self, action: #selector(handleManualEntryButton(_:)), for: .touchUpInside)
         view.addSubview(manualEntryButton)
         manualEntryButton.sizeToFit()
 
         torchButton = buttonWithTitle("Torch", imageName: "btn-torch")
+        torchButton.isAccessibilityElement = true
         torchButton.addTarget(self, action: #selector(handleTorchButton(_:)), for: .touchUpInside)
         view.addSubview(torchButton)
         torchButton.sizeToFit()

--- a/FantasmoSDKTestHarness/Base.lproj/Main.storyboard
+++ b/FantasmoSDKTestHarness/Base.lproj/Main.storyboard
@@ -300,6 +300,7 @@
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3DN-R6-LoO" userLabel="Camera Permission Button" customClass="FilledButton" customModule="FantasmoSDKTestHarness" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="137" height="60"/>
                                                 <color key="backgroundColor" systemColor="systemBlueColor"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="btn_authorize_camera"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="60" id="EvP-ih-2wN"/>
                                                 </constraints>
@@ -331,6 +332,7 @@
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark.circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="GWz-p9-9Yz">
                                                 <rect key="frame" x="227" y="0.5" width="60" height="59"/>
                                                 <color key="tintColor" systemColor="systemGreenColor"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="img_checkmark_camera"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="GWz-p9-9Yz" secondAttribute="height" id="Zwc-7S-EXq"/>
                                                 </constraints>
@@ -338,6 +340,7 @@
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="x.circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="QJB-J8-GOM">
                                                 <rect key="frame" x="302" y="0.5" width="60" height="59"/>
                                                 <color key="tintColor" systemColor="systemRedColor"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="img_cross_camera"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="QJB-J8-GOM" secondAttribute="height" id="2ft-9y-5h0"/>
                                                 </constraints>
@@ -355,6 +358,7 @@
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YLn-0G-2td" userLabel="Camera Permission Button" customClass="FilledButton" customModule="FantasmoSDKTestHarness" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="137" height="60"/>
                                                 <color key="backgroundColor" systemColor="systemBlueColor"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="btn_authorize_location"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="60" id="DER-k9-DIg"/>
                                                 </constraints>
@@ -387,6 +391,7 @@
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark.circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="MsB-0C-H8r">
                                                 <rect key="frame" x="227" y="0.5" width="60" height="59"/>
                                                 <color key="tintColor" systemColor="systemGreenColor"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="img_checkmark_location"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="MsB-0C-H8r" secondAttribute="height" id="Fcr-2q-7kf"/>
                                                 </constraints>
@@ -394,6 +399,7 @@
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="x.circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Cyn-jP-kv2">
                                                 <rect key="frame" x="302" y="0.5" width="60" height="59"/>
                                                 <color key="tintColor" systemColor="systemRedColor"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="img_cross_location"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="Cyn-jP-kv2" secondAttribute="height" id="bMY-Uc-F7b"/>
                                                 </constraints>
@@ -416,6 +422,7 @@
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8hP-r9-iyV" customClass="FilledButton" customModule="FantasmoSDKTestHarness" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="42.5" width="362" height="60"/>
                                         <color key="backgroundColor" systemColor="systemBlueColor"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="btn_continue"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="60" id="6aS-WD-fCn"/>
                                         </constraints>
@@ -503,6 +510,7 @@
                                                     </label>
                                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="IbN-bi-aOw" userLabel="Skip QR Code Switch">
                                                         <rect key="frame" x="301" y="0.0" width="51" height="31"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="tog_scanQRCode"/>
                                                     </switch>
                                                 </subviews>
                                             </stackView>
@@ -517,6 +525,7 @@
                                                     </label>
                                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="u3m-hm-PUG">
                                                         <rect key="frame" x="301" y="0.0" width="51" height="31"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="tog_debugStatistics"/>
                                                     </switch>
                                                 </subviews>
                                             </stackView>
@@ -531,6 +540,7 @@
                                                     </label>
                                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="iK8-Qy-d57">
                                                         <rect key="frame" x="301" y="0.0" width="51" height="31"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="tog_simulationMode"/>
                                                         <connections>
                                                             <action selector="handleSimulationModeSwitch:" destination="akc-1m-fZ0" eventType="valueChanged" id="nWc-z2-ozs"/>
                                                         </connections>
@@ -547,6 +557,7 @@
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bhe-Kg-zDH" customClass="FilledButton" customModule="FantasmoSDKTestHarness" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="163" width="350" height="60"/>
                                                 <color key="backgroundColor" systemColor="systemBlueColor"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="btn_localize"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="60" id="ZPZ-Rw-Oj3"/>
                                                 </constraints>
@@ -575,6 +586,9 @@
                                     </activityIndicatorView>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" editable="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="V5O-8d-Jka">
                                         <rect key="frame" x="0.0" y="243" width="350" height="422"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="txt_localizeResults">
+                                            <accessibilityTraits key="traits" staticText="YES"/>
+                                        </accessibility>
                                         <attributedString key="attributedText">
                                             <fragment>
                                                 <string key="content">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>

--- a/FantasmoSDKUITests/Actions/LocalizeActions.swift
+++ b/FantasmoSDKUITests/Actions/LocalizeActions.swift
@@ -1,0 +1,30 @@
+//
+//  LocalizeActions.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 28/4/2022.
+//
+
+import XCTest
+
+enum LocalizeActions {
+    static func toggle(_ toggle: LocalizeSwitch) {
+        LocalizeElements.getSwitch(toggle).tapWhenHittable()
+    }
+    
+    static func toggleQRCode() {
+        LocalizeElements.getSwitch(LocalizeSwitch.qrCode).tapWhenHittable()
+    }
+    
+    static func toggleDebugStats() {
+        LocalizeElements.getSwitch(LocalizeSwitch.debugStats).tapWhenHittable()
+    }
+    
+    static func toggleSimulationMode() {
+        LocalizeElements.getSwitch(LocalizeSwitch.simulationMode).tapWhenHittable()
+    }
+    
+    static func tapLocalizeButton() {
+        LocalizeElements.localizeButton().tapWhenHittable()
+    }
+}

--- a/FantasmoSDKUITests/Actions/PermissionActions.swift
+++ b/FantasmoSDKUITests/Actions/PermissionActions.swift
@@ -1,0 +1,32 @@
+//
+//  PermissionActions.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 27/4/2022.
+//
+//  Actions are static methods which encapsulate the implementation details of how to
+//  interact with elements using XCTest. There should be no assertions here.
+
+import XCTest
+
+enum PermissionActions {    
+    static func tapAuthorizeCameraButton() {
+        PermissionElements.authorizeCameraButton().tapWhenHittable()
+    }
+    
+    static func tapAuthorizeLocationButton() {
+        PermissionElements.authorizeLocationButton().tapWhenHittable()
+    }
+    
+    static func tapAllowCameraButton() {
+        PermissionElements.allowCameraButton().tapWhenHittable()
+    }
+    
+    static func tapAllowWhileUsingAppButton() {
+        PermissionElements.allowLocationButton().tapWhenHittable()
+    }
+    
+    static func tapContinueButton() {
+        PermissionElements.continueButton().tapWhenHittable()
+    }
+}

--- a/FantasmoSDKUITests/Actions/QRCodeActions.swift
+++ b/FantasmoSDKUITests/Actions/QRCodeActions.swift
@@ -1,0 +1,28 @@
+//
+//  QRCodeActions.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 11/5/2022.
+//
+
+import XCTest
+
+// these elements can be on screen but return false for "isHittable"
+// which is why we force tap them based on a coordinate
+enum QRCodeActions {
+    static func tapTorchButton() {
+        QRCodeElements.torchButton().forceTapElement()
+    }
+    
+    static func tapEnterCodeButton() {
+        QRCodeElements.enterCodeButton().forceTapElement()
+    }
+    
+    static func enterCode(_ text: String) {
+        QRCodeElements.enterQRCodeField().typeText(text)
+    }
+    
+    static func submitCode() {
+        QRCodeElements.submitQRCodeButton().tapWhenHittable()
+    }
+}

--- a/FantasmoSDKUITests/Actor.swift
+++ b/FantasmoSDKUITests/Actor.swift
@@ -1,0 +1,75 @@
+//
+//  Actor.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 27/4/2022.
+//
+//  An actor is the "person" (or thing) interacting with the AUT. The actor has a set
+//  of actions available to them in the form of tasks and can ask questions about the state
+//  of the AUT.
+
+import XCTest
+
+public class Actor {
+    let name: String
+    
+    public init(called name: String) {
+        self.name = name
+    }
+    
+    // MARK: Public
+    
+    /// Make this Actor perform a setup task.
+    ///
+    /// Interacts with the application by performing the given `task`.
+    ///
+    /// - Parameter task: Task to be performed.
+    public func has(_ task: Task) {
+        perform(task)
+    }
+    
+    /// Make this Actor perform a task which should cause your expected outcome.
+    ///
+    /// Interacts with the application by performing the given `task`.
+    ///
+    /// - Parameter task: Task to be performed.
+    public func attemptsTo(_ task: Task) {
+        perform(task)
+    }
+    
+    /// Ask a question about what this Actor sees on the screen to verify that it is what you expect.
+    ///
+    /// Enquires about the state of the application using the given `question`.
+    ///
+    /// - Parameter question: Question to be answered.
+    public func sees(_ question: Question) {
+        ask(question)
+    }
+    
+    /// Wait until a specific property of a given element becomes 'value'.
+    ///
+    /// The ability of the actor to wait is what allows them to enquire about the state of the application at the right time.
+    /// This will fail a test if the result is anything other than what was expected.
+    ///
+    /// - Parameter element: The XCUIElement to check
+    /// - Parameter property: The property (keyPath) of the element we are inspecting
+    /// - Parameter value: The value we expected the property to be
+    @discardableResult
+    public func waitsUntil(_ element: XCUIElement, _ property: String, is value: Any, for seconds: TimeInterval? = nil) -> XCTWaiter.Result {
+        let waitTime = seconds ?? UITestTimeout.element
+        let expectation = XCTKVOExpectation(keyPath: property, object: element, expectedValue: value)
+        return XCTWaiter.wait(for: [expectation], timeout: waitTime)
+    }
+    
+    // MARK: Private
+    
+    /// Ask the given question
+    private func ask(_ question: Question) {
+        question.ask()
+    }
+    
+    /// Performs the given task
+    private func perform(_ task: Task) {
+        task.perform()
+    }
+}

--- a/FantasmoSDKUITests/Config.swift
+++ b/FantasmoSDKUITests/Config.swift
@@ -1,0 +1,31 @@
+//
+//  Config.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 28/4/2022.
+//
+
+import XCTest
+
+public let AUTName = "Test Harness Dev"
+
+public struct UITestTimeout {
+    static var element: TimeInterval = 5.0
+    static var request: TimeInterval = 45.0
+}
+
+// Better booleans/state descriptors for switches and toggles
+public enum SwitchState {
+    case On
+    case Off
+}
+
+public enum ToggleState {
+    case On
+    case Off
+}
+
+public enum TorchState {
+    case On
+    case Off
+}

--- a/FantasmoSDKUITests/Elements/DebugElements.swift
+++ b/FantasmoSDKUITests/Elements/DebugElements.swift
@@ -1,0 +1,37 @@
+//
+//  DebugElements.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 2/5/2022.
+//
+
+import XCTest
+
+enum DebugTextField: String, CaseIterable {
+    case sdkVersion = "txt_sdkVersion"
+    case localizationStatus = "txt_localizationStatus"
+    case framesCurrentWindow = "txt_currentWindow"
+    case framesEvaluated = "txt_framesEvaluated"
+    case framesRejected = "txt_framesRejected"
+    case bestScore = "txt_bestScore"
+    case liveScore = "txt_liveScore"
+    case lastError = "txt_lastError"
+    case modelVersion = "txt_modelVersion"
+    case lastResult = "txt_lastResult"
+    case errorCount = "txt_errorCount"
+    case deviceLocation = "txt_deviceLocation"
+    case translation = "txt_translation"
+    case totalTranslation = "txt_totalTranslation"
+    case remoteConfigID = "txt_remoteConfigID"
+    case eulerAngles = "txt_eulerAngles"
+    case eulerAngleSpreads = "txt_eulerAngleSpreads"
+    case totalFrameRejections = "txt_totalFrameRejections"
+}
+
+enum DebugElements {
+    private static let app = XCUIApplication()
+
+    static func textField(_ field: DebugTextField) -> XCUIElement {
+        return app.staticTexts[field.rawValue]
+    }
+}

--- a/FantasmoSDKUITests/Elements/LocalizeElements.swift
+++ b/FantasmoSDKUITests/Elements/LocalizeElements.swift
@@ -1,0 +1,30 @@
+//
+//  LocalizeElements.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 28/4/2022.
+//
+
+import XCTest
+
+enum LocalizeSwitch: String, CaseIterable {
+    case qrCode = "tog_scanQRCode"
+    case debugStats = "tog_debugStatistics"
+    case simulationMode = "tog_simulationMode"
+}
+
+enum LocalizeElements {
+    private static let app = XCUIApplication()
+    
+    static func getSwitch(_ toggle: LocalizeSwitch) -> XCUIElement {
+        return app.switches[toggle.rawValue]
+    }
+    
+    static func localizeButton() -> XCUIElement {
+        return app.buttons["btn_localize"]
+    }
+    
+    static func localizeResults() -> XCUIElement {
+        return app.staticTexts["txt_localizeResults"]
+    }
+}

--- a/FantasmoSDKUITests/Elements/PermissionElements.swift
+++ b/FantasmoSDKUITests/Elements/PermissionElements.swift
@@ -1,0 +1,48 @@
+//
+//  PermissionsElements.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 27/4/2022.
+//
+//  Elements encapsulate selector logic and return a single, or multiple, elements to an
+//  Action. Element methods should never interact with anything on the page/inside a view:
+//  they exist soley as a means for abstracting away page/view selector logic from test
+//  assertions and state changes.
+
+import XCTest
+
+enum PermissionElements {
+    private static let app = XCUIApplication()
+    private static let springboardApp = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+    
+    // Might be worth having all springboard elements in a single dedicated
+    // springboard elements file
+    
+    static func authorizeCameraButton() -> XCUIElement {
+        return app.buttons["btn_authorize_camera"]
+    }
+    
+    static func authorizeLocationButton() -> XCUIElement {
+        return app.buttons["btn_authorize_location"]
+    }
+    
+    static func continueButton() -> XCUIElement {
+        return app.buttons["btn_continue"]
+    }
+    
+    static func allowLocationButton() -> XCUIElement {
+        return springboardApp.alerts.buttons["Allow While Using App"]
+    }
+    
+    static func allowCameraButton() -> XCUIElement {
+        return springboardApp.alerts.buttons["OK"]
+    }
+    
+    static func cameraCheckmarkImage() -> XCUIElement {
+        return app.images["img_checkmark_camera"]
+    }
+    
+    static func locationCheckmarkImage() -> XCUIElement {
+        return app.images["img_checkmark_location"]
+    }
+}

--- a/FantasmoSDKUITests/Elements/QRCodeElements.swift
+++ b/FantasmoSDKUITests/Elements/QRCodeElements.swift
@@ -1,0 +1,28 @@
+//
+//  QRCodeElements.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 11/5/2022.
+//
+
+import XCTest
+
+enum QRCodeElements {
+    private static let app = XCUIApplication()
+    
+    static func torchButton() -> XCUIElement {
+        return app.buttons["Torch"]
+    }
+    
+    static func enterCodeButton() -> XCUIElement {
+        return app.buttons["Enter Code"]
+    }
+    
+    static func enterQRCodeField() -> XCUIElement {
+        return app.alerts["Enter QR Code"].textFields.firstMatch
+    }
+    
+    static func submitQRCodeButton() -> XCUIElement {
+        return app.buttons["Submit"]
+    }
+}

--- a/FantasmoSDKUITests/Extensions.swift
+++ b/FantasmoSDKUITests/Extensions.swift
@@ -1,0 +1,106 @@
+//
+//  Extensions.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 3/5/2022.
+//
+
+import XCTest
+
+extension XCUIApplication {
+    // Uninstalls the AUT (needed for permission, storage, and cache clears)
+    // Edited from: https://www.jessesquires.com/blog/2021/10/25/delete-app-during-ui-tests/
+    func uninstall() {
+        self.terminate()
+
+        let timeout = TimeInterval(5)
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+
+        let appName = AUTName
+
+        /// use `firstMatch` because icon may appear in iPad dock
+        let appIcon = springboard.icons[appName].firstMatch
+        if appIcon.waitForExistence(timeout: timeout) {
+            appIcon.press(forDuration: 2)
+        } else {
+            XCTFail("Failed to find app icon named \(appName)")
+        }
+
+        let removeAppButton = springboard.buttons["Remove App"]
+        if removeAppButton.waitForExistence(timeout: timeout) {
+            removeAppButton.tap()
+        } else {
+            XCTFail("Failed to find 'Remove App'")
+        }
+
+        let deleteAppButton = springboard.alerts.buttons["Delete App"]
+        if deleteAppButton.waitForExistence(timeout: timeout) {
+            deleteAppButton.tap()
+        } else {
+            XCTFail("Failed to find 'Delete App'")
+        }
+
+        let finalDeleteButton = springboard.alerts.buttons["Delete"]
+        if finalDeleteButton.waitForExistence(timeout: timeout) {
+            finalDeleteButton.tap()
+        } else {
+            XCTFail("Failed to find 'Delete'")
+        }
+    }
+}
+
+// Check if any permissions need to be granted before we start UI tests
+extension XCUIApplication {
+    public func grantNeededPermissions() {
+
+        let btnExpectation = XCTKVOExpectation(keyPath: "exists", object: PermissionElements.continueButton(), expectedValue: true)
+
+        let btnResult = XCTWaiter.wait(for: [btnExpectation], timeout: 2.0)
+
+        /// if the continue button doesn't exist 2 seconds after app launch we assume permissions already granted
+        guard btnResult == XCTWaiter.Result.completed else {
+            return
+        }
+
+        if PermissionElements.authorizeCameraButton().isHittable {
+            PermissionActions.tapAuthorizeCameraButton()
+            PermissionActions.tapAllowCameraButton()
+        }
+
+        if PermissionElements.authorizeLocationButton().isHittable {
+            PermissionActions.tapAuthorizeLocationButton()
+            PermissionActions.tapAllowWhileUsingAppButton()
+        }
+
+        PermissionActions.tapContinueButton()
+    }
+}
+
+extension XCUIElement {
+    /// Ensures an element exists and is also hittable
+    @discardableResult
+    func waitForHittable(timeout: TimeInterval = UITestTimeout.element) -> Bool {
+        return waitForExistence(timeout: timeout) && isHittable
+    }
+}
+
+extension XCUIElement {
+    /// Tap an element when it becomes hittable
+    func tapWhenHittable(timeout: TimeInterval = UITestTimeout.element) {
+        waitForHittable(timeout: timeout)
+        tap()
+    }
+}
+
+extension XCUIElement {
+    /// Tap an element that is on screen but for some reason reports as unhittable
+    func forceTapElement() {
+        if isHittable {
+            tap()
+        }
+        else {
+            let coordinate: XCUICoordinate = coordinate(withNormalizedOffset: CGVector(dx:0.5, dy:0.5))
+            coordinate.tap()
+        }
+    }
+}

--- a/FantasmoSDKUITests/Protocols.swift
+++ b/FantasmoSDKUITests/Protocols.swift
@@ -1,0 +1,14 @@
+//
+//  Protocols.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 27/4/2022.
+//
+
+public protocol Task {
+    func perform()
+}
+
+public protocol Question {
+    func ask()
+}

--- a/FantasmoSDKUITests/Questions/DebugQuestions.swift
+++ b/FantasmoSDKUITests/Questions/DebugQuestions.swift
@@ -1,0 +1,46 @@
+//
+//  DebugQuestions.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 10/5/2022.
+//
+
+import XCTest
+import AVFoundation
+import FantasmoSDK
+
+enum Debug: Question {
+    case text(_ actual: String, _ expected: String)
+    case torch(_ actual: TorchState, _ expected: TorchState)
+    
+    func ask() {
+        switch self {
+        case .text(let actualValue, let expectedValue):
+            XCTAssertEqual(actualValue, expectedValue)
+        case .torch(let actualValue, let expectedValue):
+            XCTAssertEqual(actualValue, expectedValue)
+        }
+    }
+    
+    private static func getTorchState() -> TorchState {
+        // return off if the device has no AVCapture default device
+        guard let device = AVCaptureDevice.default(for: .video) else { return TorchState.Off }
+
+        if device.hasTorch && (device.torchMode == AVCaptureDevice.TorchMode.on || device.isTorchActive) {
+            return TorchState.On
+        }
+
+        // if no torch present or torchMode is in any other state we return off
+        return TorchState.Off
+    }
+    
+    static func DebugContent(of textField: DebugTextField, is expectedValue: String) -> Debug {
+        let actualValue = DebugElements.textField(textField).label
+        return text(actualValue, expectedValue)
+    }
+    
+    static func Torch(is expectedValue: TorchState) -> Debug {
+        let actualValue = getTorchState()
+        return torch(actualValue, expectedValue)
+    }
+}

--- a/FantasmoSDKUITests/Questions/LocalizeQuestions.swift
+++ b/FantasmoSDKUITests/Questions/LocalizeQuestions.swift
@@ -1,0 +1,49 @@
+//
+//  LocalizeQuestions.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 2/5/2022.
+//
+
+import XCTest
+
+enum Localize: Question {
+    case state(_ actual: SwitchState, _ expected: SwitchState)
+    case label(_ actual: String, _ expected: String)
+    case result(_ actual: String, _ expected: String)
+    
+    func ask() {
+        switch self {
+        case .state(let actualValue, let expectedValue):
+            XCTAssertEqual(actualValue, expectedValue)
+        
+        case .label(let actualValue, let expectedValue):
+            XCTAssertEqual(actualValue, expectedValue)
+            
+        case .result(let actualValue, let expectedValue):
+            XCTAssert(actualValue.localizedStandardContains(expectedValue))
+        }
+    }
+    
+    private static func getState(_ toggle: XCUIElement) -> SwitchState {
+        if ((toggle.value as? String) == "1") {
+            return SwitchState.On
+        }
+        return SwitchState.Off
+    }
+    
+    static func ToggleState(of toggle: LocalizeSwitch, is expectedValue: SwitchState) -> Localize {
+        let actualValue = getState(LocalizeElements.getSwitch(toggle))
+        return state(actualValue, expectedValue)
+    }
+    
+    static func LocalizeButtonLabel(is expectedValue: String) -> Localize {
+        let actualValue = LocalizeElements.localizeButton().label
+        return label(actualValue, expectedValue)
+    }
+    
+    static func ResultsContain(_ expectedValue: String) -> Localize {
+        let results = LocalizeElements.localizeResults().value as! String
+        return result(results, expectedValue)
+    }
+}

--- a/FantasmoSDKUITests/Questions/PermissionQuestions.swift
+++ b/FantasmoSDKUITests/Questions/PermissionQuestions.swift
@@ -1,0 +1,34 @@
+//
+//  PermissionQuestions.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 27/4/2022.
+//
+//  Questions are where the test assertions happen. Questions pertain to a specific domain
+//  of an application (just like our Actions, Elements, and Tasks do) and allow Actors to
+//  enquire about current state. Questions are idempotent (they are "read only", in
+//  database operations speak). Asking the same question 10 times over should always give
+//  the same answer, asynchronous/underlying state changes notwithstanding.
+
+import XCTest
+
+enum Permissions: Question {
+    case authorized(_ actual: Bool, _ expected: Bool)
+    
+    func ask() {
+        switch self {
+            case .authorized(let actualValue, let expectedValue):
+                XCTAssertEqual(actualValue, expectedValue)
+        }
+    }
+    
+    static func cameraAuthorized(is expectedValue: Bool) -> Permissions {
+        let actualValue = PermissionElements.cameraCheckmarkImage().isHittable
+        return authorized(actualValue, expectedValue)
+    }
+    
+    static func locationAuthorized(is expectedValue: Bool) -> Permissions {
+        let actualValue = PermissionElements.locationCheckmarkImage().isHittable
+        return authorized(actualValue, expectedValue)
+    }
+}

--- a/FantasmoSDKUITests/README.md
+++ b/FantasmoSDKUITests/README.md
@@ -1,0 +1,61 @@
+- [Fantasmo SDK UI Tests](#fantasmo-sdk-ui-tests)
+  * [Running Test Locally](#running-test-locally)
+  * [Microsoft App Center](#microsoft-app-center)
+    + [App Center Requirements](#app-center-requirements)
+    + [Building the XCUI Tests](#building-the-xcui-tests)
+    + [Submitting A Build For Testing](#submitting-a-build-for-testing)
+  * [Writing Tests](#writing-tests)
+
+# Fantasmo SDK UI Tests
+
+## Running Test Locally
+
+These UI tests should be run on a real device and can be run by plugging in a supported iOS device and going to Product > Test (AppleKey + U) or by clicking the Play button next to any individual test case, or a test class, from within a UI...Tests file.
+
+## Microsoft App Center
+
+The tests also run in Microsoft App Center on wide range of supported iOS devices.
+
+Access to the test runs and AppCenter build settings is restricted to Fantasmo/Tier employees but the last build status is reflected in the badge here. 
+
+[![Build status](https://build.appcenter.ms/v0.1/apps/4a527284-3333-4f45-aff1-dc68d6cead74/branches/develop/badge)](https://appcenter.ms)
+
+
+### App Center Requirements
+
+You will need:
+
+- [NodeJS](www.NodeJS.org/)
+- AppCenter Package: `npm install -g appcenter`
+
+### Building the XCUI Tests
+
+After updating or writing new UI tests a new build will need to be created which is then submitted to App Center. Use the following commnand to achieve this task:
+
+```
+rm -rf DerivedData
+xcrun xcodebuild build-for-testing \
+  -configuration Debug \
+  -sdk iphoneos \
+  -scheme FantasmoSDKTestHarnessDev \
+  -derivedDataPath DerivedData
+```
+
+### Submitting A Build For Testing
+
+To submit and run the build via App Center use the following command:
+
+```
+appcenter test run xcuitest \
+  --app "fantasmo-qa/iOS-Mobile-SDK" \
+  --devices "fantasmo-qa/ios-sdk-testing" \
+  --test-series "master" \
+  --locale "en_US" \
+  --build-dir DerivedData/Build/Products/Debug-iphoneos
+```
+
+If not already logged into AppCenter, you will be prompted to login. Your account will need to already be added as an Admin or Maintainer via AppCenter. Contact Lucas (CTO) or Nick (Lead iOS Developer) if you need access.
+
+## Writing Tests
+
+For an in depth guide to writing tests that follow the Screeplay pattern see the [Mobile Automation Principles](https://www.notion.so/fantasmo/Mobile-Automation-Principles-41390a5082704e75ba0d76c9f29837c7) document.

--- a/FantasmoSDKUITests/Tasks/LocalizeTasks.swift
+++ b/FantasmoSDKUITests/Tasks/LocalizeTasks.swift
@@ -1,0 +1,36 @@
+//
+//  LocalizeTasks.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 28/4/2022.
+//
+
+struct ToggleLocalizeSwitches: Task {
+    func perform() {
+        LocalizeActions.toggleQRCode()
+        LocalizeActions.toggleDebugStats()
+        LocalizeActions.toggleSimulationMode()
+    }
+}
+
+struct ToggleLocalizeSwitch: Task {
+    let toggle: LocalizeSwitch
+    
+    init(_ toggle: LocalizeSwitch) {
+        self.toggle = toggle
+    }
+    
+    func perform() {
+        LocalizeActions.toggle(toggle)
+    }
+    
+    static func toggle(_ toggle: LocalizeSwitch) -> ToggleLocalizeSwitch {
+        return ToggleLocalizeSwitch(toggle)
+    }
+}
+
+struct StartLocalizing: Task {
+    func perform() {
+        LocalizeActions.tapLocalizeButton()
+    }
+}

--- a/FantasmoSDKUITests/Tasks/PermissionTasks.swift
+++ b/FantasmoSDKUITests/Tasks/PermissionTasks.swift
@@ -1,0 +1,37 @@
+//
+//  PermissionsTasks.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 27/4/2022.
+//
+//  Tasks are objects which encapsulate any action which needs to be executed in order to
+//  complete that particular task. The job of a Task is to allow the author of a test to
+//  achieve some behaviour in a single line of code; without having to explicitly direct the
+//  test on what to interact with, and how to interact with it. As such, Tasks should exhibit
+//  a behavioural interface.
+
+import XCTest
+
+//  Task objects must conform to the Task protocol in order to be accepted by an Actor
+
+struct AuthorizeCamera: Task {
+    func perform() {
+        PermissionActions.tapAuthorizeCameraButton()
+        PermissionActions.tapAllowCameraButton()
+    }
+    
+    static func permission() -> AuthorizeCamera {
+        return AuthorizeCamera()
+    }
+}
+
+struct AuthorizeLocation: Task {
+    func perform() {
+        PermissionActions.tapAuthorizeLocationButton()
+        PermissionActions.tapAllowWhileUsingAppButton()
+    }
+    
+    static func permission() -> AuthorizeLocation {
+        return AuthorizeLocation()
+    }
+}

--- a/FantasmoSDKUITests/Tasks/QRCodeTasks.swift
+++ b/FantasmoSDKUITests/Tasks/QRCodeTasks.swift
@@ -1,0 +1,26 @@
+//
+//  QRCodeTasks.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 11/5/2022.
+//
+
+struct SubmitManualQRCode: Task {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+    
+    func perform() {
+        QRCodeActions.tapEnterCodeButton()
+        QRCodeActions.enterCode(text)
+        QRCodeActions.submitCode()
+    }
+}
+
+struct ToggleTorchState: Task {
+    func perform() {
+        QRCodeActions.tapTorchButton()
+    }
+}

--- a/FantasmoSDKUITests/Tests/UIReleaseProtocolTests.swift
+++ b/FantasmoSDKUITests/Tests/UIReleaseProtocolTests.swift
@@ -1,0 +1,107 @@
+//
+//  UIReleaseProtocolTests.swift
+//  FantasmoSDKUITests
+//
+//  Created by Fantasmo QA on 28/4/2022.
+//
+
+import XCTest
+
+class LocalizeTests: XCTestCase {
+    let app = XCUIApplication()
+    var alice: Actor!
+    
+    override func setUpWithError() throws {
+        // stop the test suite on test failure
+        continueAfterFailure = false
+        
+        alice = Actor(called: "Alice")
+        app.launchArguments = ["UITesting"]
+        app.launch()
+        // grant app permissions if needed
+        app.grantNeededPermissions()
+    }
+    
+    override func tearDown() {
+        // helps to clean up application state after failed tests, leave this here
+        app.terminate()
+    }
+
+      // uncomment this to uninstall the application after the test suite finishes
+//    override class func tearDown() {
+//         XCUIApplication().uninstall()
+//    }
+    
+    // test that we can toggle all toggles (switches) on and - wait for it - off!
+    func testAllToggleStates() {
+        // turn all switches on
+        alice.attemptsTo(ToggleLocalizeSwitches())
+        
+        alice.sees(Localize.ToggleState(of: LocalizeSwitch.qrCode, is: SwitchState.On))
+        alice.sees(Localize.ToggleState(of: LocalizeSwitch.debugStats, is: SwitchState.On))
+        alice.sees(Localize.ToggleState(of: LocalizeSwitch.simulationMode, is: SwitchState.On))
+        
+        // turn all switches off
+        alice.attemptsTo(ToggleLocalizeSwitches())
+        
+        alice.sees(Localize.ToggleState(of: LocalizeSwitch.qrCode, is: SwitchState.Off))
+        alice.sees(Localize.ToggleState(of: LocalizeSwitch.debugStats, is: SwitchState.Off))
+        alice.sees(Localize.ToggleState(of: LocalizeSwitch.simulationMode, is: SwitchState.Off))
+    }
+    
+    // test simulation mode is working (targets dev environment)
+    func testSimulationMode() {
+        let sdkVersion = "Fantasmo SDK " + ProcessInfo.processInfo.environment["SDK_VERSION"]!
+        
+        // switch on simulation mode, debug toggle, and skip QR code
+        alice.attemptsTo(ToggleLocalizeSwitches())
+        
+        // check localize button and toggle state are correct
+        alice.sees(Localize.LocalizeButtonLabel(is: "Localize (Simulation)"))
+        alice.sees(Localize.ToggleState(of: LocalizeSwitch.simulationMode, is: SwitchState.On))
+       
+        // begin localizing (hit localize button) and wait until SDK UI appears
+        alice.attemptsTo(StartLocalizing())
+        
+        // wait for the localization session to properly begin
+        alice.waitsUntil(DebugElements.textField(DebugTextField.sdkVersion), "isHittable", is: true, for: 10.0)
+        alice.waitsUntil(DebugElements.textField(DebugTextField.localizationStatus), "label", is: "Status: localizing")
+        
+        // check the SDK version number is correct
+        // this also tells us skipping QR code entry is working
+        alice.sees(Debug.DebugContent(of: DebugTextField.sdkVersion, is: sdkVersion))
+        
+        // wait a while for localization session to finish, always waits the entire time for some reason
+        alice.waitsUntil(LocalizeElements.localizeResults(), "isHittable", is: true, for: UITestTimeout.request)
+        
+        // check results have at least one entry with high confidence
+        alice.sees(Localize.ResultsContain("Confidence: High"))
+    }
+    
+    // MARK: need an AR session that doesn't have a QR code at the start for this to pass
+    // manual QR code entry as well as flashlight toggle
+    func testQRCodeFunctions() {
+        let stopped = "Status: stopped"
+        let localizing = "Status: localizing"
+        
+        // turn on simulation mode and debug stats
+        alice.attemptsTo(ToggleLocalizeSwitch(LocalizeSwitch.simulationMode))
+        alice.attemptsTo(ToggleLocalizeSwitch(LocalizeSwitch.debugStats))
+        alice.attemptsTo(StartLocalizing())
+        alice.waitsUntil(DebugElements.textField(DebugTextField.sdkVersion), "isHittable", is: true, for: 10.0)
+        
+        // toggle torch state on and then wait a second
+        alice.attemptsTo(ToggleTorchState())
+        // alice.sees(Debug.Torch(is: TorchState.On))
+
+        // test localizing is stopped before manual QR code entry is done
+        alice.sees(Debug.DebugContent(of: DebugTextField.localizationStatus, is: stopped))
+        alice.attemptsTo(SubmitManualQRCode("qr-code"))
+        
+        // test localizing has begun after manual QR code entry is done
+        alice.sees(Debug.DebugContent(of: DebugTextField.localizationStatus, is: localizing))
+        
+        // torch should automatically turn off after succesul QR code scan or entry
+        alice.sees(Debug.Torch(is: TorchState.Off))
+    }
+}


### PR DESCRIPTION
This PR:

- ~~adds AppCenter integration~~
- add iOS UI tests
- adds readme for UI tests
- adds accessibility IDs to existing elements inside the FantasmoSDKTestHarness app
- ~~adds a post build script to trigger UI test run after push to develop~~
- implements the strategies outlined in the new [Mobile Automation Principles](https://www.notion.so/fantasmo/Mobile-Automation-Principles-41390a5082704e75ba0d76c9f29837c7) doc